### PR TITLE
Added the login/register page

### DIFF
--- a/frontend/src/features/Entry/entry.css
+++ b/frontend/src/features/Entry/entry.css
@@ -1,0 +1,122 @@
+body {
+    background-image: url(image/gallery.gif);
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-attachment: fixed;
+    overflow: hidden;
+}
+
+dialog {
+    width: 50vh;
+    height: 45vh;
+    border: none;
+    border-radius: 3vh;
+    background-color: #1d1e1a;
+    text-align: center;
+    font-family: "Lexend", "Montserrat", sans-serif;
+    padding: 0vh;
+}
+
+dialog::backdrop {
+    opacity: 30%;
+    background-color: black;
+}
+
+dialog h1,
+dialog h2 {
+    margin: 0vh;
+    margin-top: 2vh;
+    margin-bottom: 2vh;
+    padding: 0vh;
+}
+
+dialog h1 {
+    color: #ffffff;
+    font-size: 5vh;
+}
+
+dialog h1 span {
+    color: #deb887;
+}
+
+dialog h2 {
+    color: #ffffff;
+    font-size: 3vh;
+}
+
+dialog p {
+    font-size: 1.5vh;
+    margin: 0vh;
+    padding: 0vh;
+}
+
+dialog form {
+    margin: 0vh;
+    padding: 0vh;
+}
+
+dialog form + p {
+    color: #deb887;
+    text-decoration: underline;
+    cursor: pointer;
+    user-select: none;
+    margin: 1vh;
+    padding: 0vh;
+}
+
+dialog form p {
+    color: #dc143c;
+    font-weight: bold;
+    /* visibility: hidden; */
+}
+
+dialog form input.username,
+dialog form input.password
+{
+    width: 30vh;
+    height: 2vh;
+    border: 0.5vh solid #deb887;
+    border-radius: 1vh;
+    margin: 0.75vh;
+    padding: 1vh;
+}
+
+dialog form input.remember {
+    width: 1.1vh;
+    height: 1.1vh;
+    margin: 0vh;
+    padding: 0vh;
+}
+
+dialog form input.remember + label {
+    width: 2vh;
+    height: 2vh;
+    color: white;
+    font-size: 1.5vh;
+    user-select: none;
+    margin: 0vh;
+    margin-left: 0.25vh;
+    padding: 0vh;
+}
+
+dialog form input.submit {
+    width: 20vh;
+    height: 4vh;
+    border: none;
+    border-radius: 1vh;
+    background-color: #deb887;
+    font-size: 1.5vh;
+    font-weight: bold;
+    font-family: "Lexend", "Montserrat", sans-serif;
+    margin: 0.75vh;
+    padding: 1vh;
+    cursor: pointer;
+}
+
+dialog form input::placeholder,
+dialog form input[type="text"],
+dialog form input[type="password"] {
+    font-size: 1.5vh;
+    font-family: "Lexend", "Montserrat", sans-serif;
+}

--- a/frontend/src/features/Entry/entry.html
+++ b/frontend/src/features/Entry/entry.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+<html>
+
+    <head>
+
+        <title>Login/Register</title>
+
+        <link rel="stylesheet" href="entry.css">
+
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+    </head>
+
+    <body>
+
+        <!-- for login -->
+
+        <dialog id="login">
+
+            <h1>CARPS <span>TO GO!</span></h1>
+
+            <h2>Login</h2>
+
+            <form method="get">
+                <input class="username" type="text" placeholder="Username" required> <br>
+                <input class="password" type="password" placeholder="Password" required> <br>
+                <input class="remember" id="rememberLogin" type="checkbox"> <label for="rememberLogin">Remember me?</label>
+                <p>Invalid Username and Password</p>
+                <input class="submit" type="submit" value="Login">
+            </form>
+            <p onclick=startRegister()>Don't have an account? Register here!</p>
+
+        </dialog>
+
+        <!-- for register -->
+
+        <dialog id="register">
+
+            <h1>CARPS <span>TO GO!</span></h1>
+
+            <h2>Register</h2>
+            <form method="push">
+                <input class="username" type="text" placeholder="Username" required> <br>
+                <input class="password" type="password" placeholder="Password" required> <br>
+                <input class="remember" id="rememberRegister" type="checkbox"> <label for="rememberRegister">Remember me?</label>
+                <p>Username and Password Already Taken</p>
+                <input class="submit" type="submit" value="Register">
+            </form>
+
+            <p onclick=startLogin()>Already have an account? Login here!</p>
+
+        </dialog>
+
+        <script src="entry.js"></script>
+    
+    </body>
+
+</html>

--- a/frontend/src/features/Entry/entry.js
+++ b/frontend/src/features/Entry/entry.js
@@ -1,0 +1,19 @@
+const login = document.getElementById("login");
+const register = document.getElementById("register");
+
+startLogin();
+
+function startLogin() {
+    login.showModal();
+    register.close();
+}
+
+function startRegister() {
+    login.close();
+    register.showModal();
+}
+
+function endAll() {
+    login.close();
+    register.close();
+}


### PR DESCRIPTION
Currently, both the login and registration are on one page, and it has no further logic to redirect the user back to the home page. Technically, it is possible to use the current HTML to just have a popup on the home page. Aside from that, the styling of the elements are not optimized to be responsive. Note that this is not compatible with the current repository since it's not yet converted for use in React.