### PR TITLE
Added the create-post page

### DIFF
--- a/frontend/src/features/CreatePost/create.css
+++ b/frontend/src/features/CreatePost/create.css
@@ -1,0 +1,84 @@
+body {
+    color: white;
+    background-color: #1c1d19;
+    font-family: "Lexend", "Montserrat", sans-serif;
+    text-align: center;
+}
+
+h1 {
+    font-size: 3em;
+}
+
+form p {
+    font-size: 1.15em;
+    margin-top: 35px;
+}
+
+form input.text {
+    width: 30vh;
+    height: 2vh;
+    border: 0.5vh solid #deb887;
+    border-radius: 1vh;
+    padding: 1vh;
+}
+
+div.toggle {
+    border-radius: 15px;
+    display: inline-block;
+    min-width: 75px;
+    margin: 5px;
+}
+
+div.toggle label {
+    color: black;
+    font-weight: bold;
+    display: block;
+    user-select: none;
+    padding: 2px;
+    padding-left: 10px;
+    padding-right: 10px;
+    background-color: lightgray;
+    border-radius: 15px;
+    text-align: center;
+    width: 100px;
+}
+
+div.toggle input {
+    display: none;
+}
+
+input:checked + label {
+    background-color: #deb887;
+}
+
+form textarea {
+    width: 63vh;
+    height: 20vh;
+    border: 0.5vh solid #deb887;
+    border-radius: 2vh;
+    padding: 1vh;
+    resize: none;
+    margin-bottom: 35px;
+}
+
+form input.submit {
+    width: 20vh;
+    height: 4vh;
+    border: none;
+    border-radius: 1vh;
+    background-color: #deb887;
+    font-size: 1.5vh;
+    font-weight: bold;
+    font-family: "Lexend", "Montserrat", sans-serif;
+    margin: 0.75vh;
+    padding: 1vh;
+    cursor: pointer;
+}
+
+form input::placeholder,
+form textarea::placeholder,
+form input[type="text"],
+form textarea {
+    font-size: 1.5vh;
+    font-family: "Lexend", "Montserrat", sans-serif;
+}

--- a/frontend/src/features/CreatePost/create.html
+++ b/frontend/src/features/CreatePost/create.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+
+<html>
+
+    <head>
+
+        <title>Create Post</title>
+
+        <link rel="stylesheet" href="create.css">
+
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+    </head>
+
+    <body>
+
+        <h1>Create Post</h1>
+
+        <form method="post">
+
+            <p>Enter the start and destination.</p>
+
+            <input class="text" type="text" placeholder="Start" maxlength="100" required>
+            <input class="text" type="text" placeholder="Destination" maxlength="100" required>
+
+            <p>Select the type of the trip.</p>
+
+            <div class="toggle">
+                <input name="type" id="one-way" type="radio" checked>
+                <labeL for="one-way">One-Way</labeL>
+            </div>
+
+            <div class="toggle">
+                <input name="type" id="round" type="radio">
+                <labeL for="round">Round</labeL>
+            </div>
+
+            <p>Select the preferred mode of public transport. <br> 
+               Multiple selections are allowed.</p>
+
+            <div class="toggle">
+                <input id="tricycle" type="checkbox">
+                <label for="tricycle">Tricycle</label>
+            </div>
+
+            <div class="toggle">
+                <input id="jeep" type="checkbox">
+                <label for="jeep">Jeep</label>
+            </div>
+
+            <div class="toggle">
+                <input id="taxi" type="checkbox">
+                <label for="taxi">Taxi</label>
+            </div>
+
+            <br>
+
+            <div class="toggle">
+                <input id="van" type="checkbox">
+                <label for="van">Van</label>
+            </div>
+
+            <div class="toggle">
+                <input id="bus" type="checkbox">
+                <label for="bus">Bus</label>
+            </div>
+
+            <div class="toggle">
+                <input id="train" type="checkbox">
+                <label for="train">Train</label>
+            </div>
+
+            <br>
+
+            <div class="toggle">
+                <input id="angkas" type="checkbox">
+                <label for="angkas">Angkas</label>
+            </div>
+
+            <div class="toggle">
+                <input id="grab" type="checkbox">
+                <label for="grab">Grab</label>
+            </div>
+
+            <p>Enter any additional details.</p>
+
+            <textarea id="description" placeholder="Description" maxlength="2500"></textarea> <br>
+
+            <input class="submit" type="submit" value="Post">
+
+        </form>
+
+        <script src="create.js"></script>
+
+    </body>
+
+</html>


### PR DESCRIPTION
Currently, the create-post page is not optimized to be responsive. Technically, it is also possible to use this page for the edit-post page, given that the inner HTML of the h1 tag is changed to "Edit Post" while reflecting the current data in the form tag. Note that this is not compatible with the current repository since it's not yet converted for use in React.