### PR TITLE
Implemented On Delete Cascade

### DIFF
--- a/backend/controllers/votesController.js
+++ b/backend/controllers/votesController.js
@@ -80,14 +80,14 @@ const voteComment = async (req, res, next) => {
         } else {
             await CommentVote.updateOne(
                 { user: userID, comment: commentID },
-                { impression: vote }
+                { impression: vote === 1 }
             )
         }
     } else {
         await CommentVote.create({
             user: userID,
             comment: commentID,
-            impression: vote
+            impression: vote === 1
         });
     }
 

--- a/backend/models/comment.js
+++ b/backend/models/comment.js
@@ -1,15 +1,33 @@
 import mongoose from 'mongoose';
 
+import { CommentVote } from '../models/commentvote.js';
+
 // local connection
 mongoose.connect("mongodb://localhost:27017/carps");
 
-const schema = {
+const schema = new mongoose.Schema ({
     user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
     parentPost: { type: mongoose.Schema.Types.ObjectId, ref: "Post", required: true },
     parentComment: { type: mongoose.Schema.Types.ObjectId, ref: "Comment" },
     comment: { type: String, required: true },
     timestamp: { type: Date, required: true }
-};
+});
+
+schema.post('findOneAndDelete', async (doc) => {
+
+    if (doc) {
+
+        const comments = await Comment.find({ parentComment: doc._id });
+
+        for (const comment of comments) {
+            await Comment.findOneAndDelete({ _id: comment._id, parentComment: doc._id });
+        }
+
+        await CommentVote.deleteMany({ comment: doc._id });
+
+    }
+
+});
 
 const Comment = mongoose.model("Comment", schema);
 

--- a/backend/models/post.js
+++ b/backend/models/post.js
@@ -1,9 +1,13 @@
 import mongoose from 'mongoose';
 
+import { Comment } from '../models/comment.js';
+import { PostVote } from '../models/postvote.js';
+import { Save } from '../models/save.js';
+
 // local connection
 mongoose.connect("mongodb://localhost:27017/carps");
 
-const schema = {
+const schema = new mongoose.Schema ({
     user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
     start: { type: String, required: true },
     destination: { type: String, required: true },
@@ -11,7 +15,24 @@ const schema = {
     isOneWay: { type: Boolean, required: true },
     description: { type: String },
     timestamp: { type: Date, required: true }
-};
+});
+
+schema.post('findOneAndDelete', async (doc) => {
+
+    if (doc) {
+
+        const comments = await Comment.find({ parentPost: doc._id });
+
+        for (const comment of comments) {
+            await Comment.findOneAndDelete({ _id: comment._id, parentPost: doc._id });
+        }
+
+        await PostVote.deleteMany({ post: doc._id });
+        await Save.deleteMany({ post: doc._id });
+
+    }
+
+});
 
 const Post = mongoose.model("Post", schema);
 


### PR DESCRIPTION
Before, we did not handle any cascading changes within the database. For example, if there are there users who commented on a particular post, what will happen if the post is deleted? On the frontend, it becomes inaccessible, but the database will still store those comments even if the post is already deleted.

Thus, I addressed this issue, and any deletion of a parent will delete all of its children, grandchildren, and so on and so forth.

Another thing I noticed while testing this was that there was an error in the comment votes. Before, it was just { impression: vote }, which led to errors from MongoDB since it was expecting a Boolean value. Now, it is { impression: vote === 1 }.